### PR TITLE
Restore support for reading from standard in when using 2.x parsing arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '8.0'
   - '7.10'
   - '6.10'
-  - '5.12'
 deploy:
   - provider: releases
     api_key:

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -34,6 +34,34 @@ function getEncoding(format: string) {
   }
 }
 
+function legacyOptionsParsing(argv: string[]) {
+  const options: any = {}
+  var unnamedArgs = [] as string[];
+  argv.slice(2).forEach(
+    function (x) {
+      if (x[0] === "-") {
+        var i = x.indexOf("=");
+        options[x.substr(1, i > 0 ? i - 1 : undefined)] = i > 0 ? x.substr(i + 1) : true;
+      }
+      else unnamedArgs.push(x);
+    });
+
+  return { options, unnamedArgs };
+}
+
+async function legacyEncode(options: any, input: any) {
+  if (options.c) {
+    return JSON.stringify(input);
+  }
+
+  if (options.h) {
+    return await anyjson.encode(input, "hjson");
+  }
+
+  // options.j or default
+  return await anyjson.encode(input, "json");
+}
+
 const generalOptions: Array<dashdash.Option | dashdash.Group> =
   [
     {
@@ -127,16 +155,7 @@ ${help}`
 
   if (!commandSpecified) {
     // Try legacy argument format
-    const options: any = {}
-    var unnamedArgs = [] as string[];
-    argv.slice(2).forEach(
-      function (x) {
-        if (x[0] === "-") {
-          var i = x.indexOf("=");
-          options[x.substr(1, i > 0 ? i - 1 : undefined)] = i > 0 ? x.substr(i + 1) : true;
-        }
-        else unnamedArgs.push(x);
-      });
+    const { options, unnamedArgs } = legacyOptionsParsing(argv);
 
     const legacyProperties = ["j", "c", "h", "format", "opt"]
 
@@ -162,16 +181,7 @@ for help use 'any-json -?`;
       const format = options.format || getFormatFromFileName(unnamedArgs[0]);
       const input = await anyjson.decode(await readFile(unnamedArgs[0], 'utf8'), format);
 
-      if (options.c) {
-        return JSON.stringify(input);
-      }
-
-      if (options.h) {
-        return await anyjson.encode(input, "hjson");
-      }
-
-      // options.j or default
-      return await anyjson.encode(input, "json");
+      return await legacyEncode(options, input);
     }
     // Not legacy parsing continue as usual
   }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/xlsx": "0.0.34",
     "@types/xml2js": "^0.4.0",
     "chai": "^4.0.2",
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "mock-stdin": "^0.3.1"
   }
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -68,6 +68,23 @@ suite("Command Line Application", () => {
       const result = await main(args(`-format=ini ${file}`));
       assert.strictEqual(result, fs.readFileSync(path.join(__dirname, 'fixtures', 'in', `product-set.ini.json`), 'utf8'))
     })
+
+    test("reading from stdin", async () => {
+      require('mock-stdin').stdin();
+      const resultPromise = main(args(`-format=hjson`));
+
+      const mockStdin: any = process.stdin;
+      mockStdin.send("{key:1}");
+      mockStdin.send(null);
+
+      assert.strictEqual(await resultPromise, '{\n    "key": 1\n}');
+    })
+
+    test("reading from stdin requires format argument", async () => {
+      const result = await main(args(``)) as string;
+
+      assert.match(result, /^usage:.*/);
+    })
   })
 
   suite("convert", () => {


### PR DESCRIPTION
Restore support for reading from standard in when using 2.x parsing argumentsRestore support for reading from standard in when using 2.x parsing arguments.

Implementation/follow-up for https://github.com/any-json/any-json/pull/5#issuecomment-318864756