### PR TITLE
update product-set.cson test output file to use single quotes

### DIFF
--- a/test/fixtures/out/product-set.cson
+++ b/test/fixtures/out/product-set.cson
@@ -1,11 +1,11 @@
 [
   {
     id: 2
-    name: "An ice sculpture"
+    name: 'An ice sculpture'
     price: 12.5
     tags: [
-      "cold"
-      "ice"
+      'cold'
+      'ice'
     ]
     dimensions:
       length: 7
@@ -17,7 +17,7 @@
   }
   {
     id: 3
-    name: "A blue mouse"
+    name: 'A blue mouse'
     price: 25.5
     dimensions:
       length: 3.1


### PR DESCRIPTION
[cson-parser](https://www.npmjs.com/package/cson-parser) (the underlying parser used by [cson](https://www.npmjs.com/package/cson) npm lib) now uses single quotes by default and has option for double quotes. but, the cson library doesn't support the double quotes option at this moment.

Here's the [PR](https://github.com/groupon/cson-parser/pull/63) that makes single quotes the default option in cson-parser.
Here's the [Discussion](https://github.com/groupon/cson-parser/issues/62) for the change in cson-parser.

**We will have to mention this as a breaking change in the next Version.**